### PR TITLE
feat: agregar soporte para etiquetas en la creación de subforos

### DIFF
--- a/internal/controllers/subforo.controller.go
+++ b/internal/controllers/subforo.controller.go
@@ -137,10 +137,19 @@ func (c *SubforoController) Create(w http.ResponseWriter, r *http.Request) {
 		moderators = filterEmptyStrings(moderators)
 	}
 
+	tags := []string{}
+	rawTags := r.FormValue("categories")
+	if rawTags != "" {
+		if err := json.Unmarshal([]byte(rawTags), &tags); err != nil {
+			http.Error(w, "tags inválidos", http.StatusBadRequest)
+			return
+		}
+	}
+
 	subforo := models.Subforo{
 		Title:       r.FormValue("title"),
 		Description: r.FormValue("description"),
-		Categories:  strings.Split(r.FormValue("categories"), ","),
+		Categories:  tags, 
 		Moderators:  moderators,
 	}
 
@@ -157,7 +166,7 @@ func (c *SubforoController) Create(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if bannerFile, _, err := r.FormFile("banner"); err == nil {
+	if bannerFile, _, err := r.FormFile("banner_url"); err == nil {
 		defer bannerFile.Close()
 		if bannerURL, err := c.uploadImageToCloudinary(bannerFile, "banner_"+time.Now().Format("20060102150405")); err == nil {
 			subforo.BannerURL = bannerURL
@@ -167,7 +176,7 @@ func (c *SubforoController) Create(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	if iconFile, _, err := r.FormFile("icon"); err == nil {
+	if iconFile, _, err := r.FormFile("icon_url"); err == nil {
 		defer iconFile.Close()
 		if iconURL, err := c.uploadImageToCloudinary(iconFile, "icon_"+time.Now().Format("20060102150405")); err == nil {
 			subforo.IconURL = iconURL


### PR DESCRIPTION
This pull request updates the `Create` method in `SubforoController` to improve handling of form data and image uploads. The most significant changes include parsing JSON-formatted tags, renaming form fields for clarity, and ensuring consistent handling of uploaded images.

### Improvements to form data handling:
* [`internal/controllers/subforo.controller.go`](diffhunk://#diff-503af12e237150cb94a70ebb163c00378a182986900a8f22976abdc1d74c643cR140-R152): Added logic to parse JSON-formatted tags from the `categories` form field, replacing the previous comma-separated string approach. This improves validation and flexibility for handling tags.

### Enhancements to image upload functionality:
* [`internal/controllers/subforo.controller.go`](diffhunk://#diff-503af12e237150cb94a70ebb163c00378a182986900a8f22976abdc1d74c643cL160-R169): Renamed form fields `banner` to `banner_url` and `icon` to `icon_url` for clarity and consistency with their usage. [[1]](diffhunk://#diff-503af12e237150cb94a70ebb163c00378a182986900a8f22976abdc1d74c643cL160-R169) [[2]](diffhunk://#diff-503af12e237150cb94a70ebb163c00378a182986900a8f22976abdc1d74c643cL170-R179)