### PR TITLE
feat: add endpoint to retrieve posts by forum ID 

### DIFF
--- a/internal/controllers/post_controller.go
+++ b/internal/controllers/post_controller.go
@@ -403,3 +403,29 @@ func (c *PostController) IsSaved(w http.ResponseWriter, r *http.Request) {
     w.Header().Set("Content-Type", "application/json")
     json.NewEncoder(w).Encode(map[string]bool{"saved": saved})
 }
+
+// @Summary Obtener posts de un subforo
+// @Description Obtiene todos los posts que pertenecen a un subforo (forum_id).
+// @Tags Post
+// @Accept json
+// @Produce json
+// @Param forum_id path string true "ID del subforo"
+// @Success 200 {array} models.Post "Lista de posts del subforo"
+// @Failure 400 {object} map[string]string "forum_id es obligatorio"
+// @Failure 500 {object} map[string]string "Error interno"
+// @Router /public/posts/forum/{forum_id} [get]
+func (c *PostController) GetPostsByForumID(w http.ResponseWriter, r *http.Request) {
+    vars := mux.Vars(r)
+    forumID := vars["forum_id"]
+    if forumID == "" {
+        http.Error(w, "forum_id es obligatorio", http.StatusBadRequest)
+        return
+    }
+    posts, err := c.postUsecase.GetPostsByForumID(r.Context(), forumID)
+    if err != nil {
+        http.Error(w, "Error obteniendo posts del foro", http.StatusInternalServerError)
+        return
+    }
+    w.Header().Set("Content-Type", "application/json")
+    json.NewEncoder(w).Encode(posts)
+}

--- a/internal/usecases/post_usecase.go
+++ b/internal/usecases/post_usecase.go
@@ -42,10 +42,11 @@ func (u *PostUsecase) CreatePost(ctx context.Context, p *models.Post) (*models.P
 			p.Verdict = "No se pudo analizar el contenido"
 		} else {
 			// Calcular similitud y obtener veredicto
-			_, verdict, err := service.CalculateTextSimilarity(p.Content, subforo.Description)
+			_, verdict, err := service.CalculateTextSimilarity(p.Title+" "+p.Content, subforo.Description)
 			if err != nil {
 				// Si hay error en el análisis, continuar sin veredicto
-				p.Verdict = "Error en el análisis de contenido"
+				return nil, err
+				p.Verdict = "Error en el análisis de contenido"	
 			} else {
 				p.Verdict = verdict
 			}
@@ -91,4 +92,8 @@ func (u *PostUsecase) GetSavedPosts(ctx context.Context, userID string) ([]*mode
 
 func (u *PostUsecase) IsPostSaved(ctx context.Context, userID, postID string) (bool, error) {
     return u.repo.IsPostSavedByUser(ctx, userID, postID)
+}
+
+func (u *PostUsecase) GetPostsByForumID(ctx context.Context, forumID string) ([]*models.Post, error) {
+    return u.repo.GetPostsByForumID(ctx, forumID)
 }

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ func main() {
 	publicRouter.HandleFunc("/users", userController.GetUser).Methods("GET")
 	publicRouter.HandleFunc("/forgot-password", handlers.ForgotPasswordHandler(authService)).Methods("POST")
 	publicRouter.HandleFunc("/posts", postController.GetAll).Methods("GET")
+	publicRouter.HandleFunc("/posts/forum/{forum_id}", postController.GetPostsByForumID).Methods("GET")
 	publicRouter.HandleFunc("/posts", postController.Create).Methods("POST")
 	publicRouter.HandleFunc("/post/{id}", postController.GetByID).Methods("GET")
 	publicRouter.HandleFunc("/votes/user", voteController.GetUserVote).Methods("GET")


### PR DESCRIPTION
This pull request introduces functionality to retrieve posts by forum ID, along with associated changes across the controller, repository, usecase, and routing layers. Additionally, it includes a minor update to the content similarity analysis logic.

### New functionality: Retrieve posts by forum ID

* **Controller layer**: Added `GetPostsByForumID` method to `PostController` to handle HTTP requests for retrieving posts by forum ID. Includes validation for `forum_id` and error handling for internal issues.
* **Repository layer**: Added `GetPostsByForumID` method to `PostRepository` to query the database for posts belonging to a specific forum ID. Includes fetching author details and sorting posts by creation date in descending order.
* **Usecase layer**: Added `GetPostsByForumID` method to `PostUsecase` to connect the repository logic with the controller.
* **Routing**: Updated `main.go` to register the new route `/posts/forum/{forum_id}` for handling GET requests.

### Minor update: Content similarity analysis

* **Usecase layer**: Modified the content similarity analysis logic in `CreatePost` to include the post title in the comparison with the forum description. Added error handling for issues during analysis.